### PR TITLE
fixes for better errorhandling

### DIFF
--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -51,11 +51,19 @@ function process(proxyIntegrationConfig, event) {
             try {
                 event.body = JSON.parse(event.body);
             } catch (parseError) {
-                return Promise.resolve({statusCode: 400, headers: headers, body: 'body is not a valid JSON'});
+                return Promise.resolve({
+                    statusCode: 400,
+                    headers: headers,
+                    body: 'body is not a valid JSON'
+                });
             }
         }
         return Promise.resolve(actionConfig.action(event)).then(res => {
-            return {statusCode: 200, headers: headers, body: JSON.stringify(res)};
+            return {
+                statusCode: 200,
+                headers: headers,
+                body: JSON.stringify(res)
+            };
         }).catch(err => {
             return convertError(err, errorMapping, headers);
         });
@@ -85,9 +93,16 @@ function convertError(error, errorMapping, headers) {
             return {statusCode: error.status, body: JSON.stringify(error.message), headers: addCorsHeaders({})};
         }
         try{
-            return {statusCode: 500, body: `Generic error: ${JSON.stringify(error)}`, headers: addCorsHeaders({})};
+            return {
+                statusCode: 500,
+                body: `Generic error: ${JSON.stringify(error)}`,
+                headers: addCorsHeaders({})
+            };
         }catch(stringifyError){}
-        return {statusCode: 500, body: `Generic error: ${error.stack ? error.stack : error}`};
+        return {
+            statusCode: 500,
+            body: `Generic error: ${error.stack ? error.stack : error}`
+        };
 }
 
 function findMatchingActionConfig(httpMethod, httpPath, routeConfig) {

--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -7,6 +7,13 @@ const NO_MATCHING_ACTION = request => {
     }
 };
 
+function addCorsHeaders(toAdd) {
+    toAdd["Access-Control-Allow-Origin"] = "*";
+    toAdd["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,HEAD";
+    toAdd["Access-Control-Allow-Headers"] = "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token";
+    return toAdd;
+}
+
 function process(proxyIntegrationConfig, event) {
     //validate config
     if (!Array.isArray(proxyIntegrationConfig.routes) || proxyIntegrationConfig.routes.length < 1) {
@@ -20,9 +27,7 @@ function process(proxyIntegrationConfig, event) {
 
     let headers = {};
     if (proxyIntegrationConfig.cors) {
-        headers["Access-Control-Allow-Origin"] = "*";
-        headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,HEAD";
-        headers["Access-Control-Allow-Headers"] = "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token";
+        addCorsHeaders(headers);
         if (event.httpMethod === 'OPTIONS') {
             return Promise.resolve({statusCode: 200, headers: headers, body: ''});
         }
@@ -77,9 +82,12 @@ function convertError(error, errorMapping, headers) {
         if (typeof error.reason === 'string' && errorMapping && errorMapping[error.reason]) {
             return {statusCode: errorMapping[error.reason], body: error.message, headers: headers};
         }else if(typeof error.status === 'number'){
-            return {statusCode: error.status, body: error.message, headers: headers};
+            return {statusCode: error.status, body: error.message, headers: addCorsHeaders({})};
         }
-        return {statusCode: 500, body: `Generic error: ${error.stack ? error.stack : error}`, headers: headers};
+        try{
+            return {statusCode: 500, body: `Generic error: ${JSON.stringify(error)}`, headers: addCorsHeaders({})};
+        }catch(stringifyError){}
+        return {statusCode: 500, body: `Generic error: ${error.stack ? error.stack : error}`};
 }
 
 function findMatchingActionConfig(httpMethod, httpPath, routeConfig) {

--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -64,7 +64,7 @@ function normalizeRequestPath(event) {
     // ugly hack: if host is from API-Gateway 'Custom Domain Name Mapping', then event.path has the value '/basepath/resource-path/';
     // if host is from amazonaws.com, then event.path is just '/resource-path':
     const apiId = event.requestContext ? event.requestContext.apiId : null; // the apiId that is the first part of the amazonaws.com-host
-    if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) != apiId)) {
+    if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) !== apiId)) {
         // remove first path element:
         const groups = /\/[^\/]+(.*)/.exec(event.path) || [null, null];
         return groups[1] || '/';
@@ -74,15 +74,17 @@ function normalizeRequestPath(event) {
 }
 
 function convertError(error, errorMapping, headers) {
-    if (typeof error.reason === 'string' && typeof error.message === 'string' && errorMapping && errorMapping[error.reason]) {
-        return {statusCode: errorMapping[error.reason], body: error.message, headers: headers};
-    }
-    return {statusCode: 500, body: `Generic error: ${JSON.stringify(error)}`};
+        if (typeof error.reason === 'string' && errorMapping && errorMapping[error.reason]) {
+            return {statusCode: errorMapping[error.reason], body: error.message, headers: headers};
+        }else if(typeof error.status === 'number'){
+            return {statusCode: error.status, body: error.message, headers: headers};
+        }
+        return {statusCode: 500, body: `Generic error: ${error.stack ? error.stack : error}`, headers: headers};
 }
 
 function findMatchingActionConfig(httpMethod, httpPath, routeConfig) {
     const paths = {};
-    const matchingMethodRoutes = routeConfig.routes.filter(route => route.method == httpMethod);
+    const matchingMethodRoutes = routeConfig.routes.filter(route => route.method === httpMethod);
     for (let route of matchingMethodRoutes) {
         if (routeConfig.debug) {
             console.log(`Examining route ${route.path} to match ${httpPath}`);

--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -80,9 +80,9 @@ function normalizeRequestPath(event) {
 
 function convertError(error, errorMapping, headers) {
         if (typeof error.reason === 'string' && errorMapping && errorMapping[error.reason]) {
-            return {statusCode: errorMapping[error.reason], body: error.message, headers: headers};
+            return {statusCode: errorMapping[error.reason], body: JSON.stringify(error.message), headers: headers};
         }else if(typeof error.status === 'number'){
-            return {statusCode: error.status, body: error.message, headers: addCorsHeaders({})};
+            return {statusCode: error.status, body: JSON.stringify(error.message), headers: addCorsHeaders({})};
         }
         try{
             return {statusCode: 500, body: `Generic error: ${JSON.stringify(error)}`, headers: addCorsHeaders({})};

--- a/test/proxyIntegration.spec.js
+++ b/test/proxyIntegration.spec.js
@@ -306,7 +306,7 @@ describe('proxyIntegration.routeHandler', () => {
         proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(result => {
             expect(result).toEqual({
                 statusCode: 501,
-                body: 'bla',
+                body: '"bla"',
                 headers: Object.assign({"Content-Type": "application/json"}, expectedCorsHeaders)
             });
             done();
@@ -350,7 +350,7 @@ describe('proxyIntegration.routeHandler', () => {
         proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(result => {
             expect(result).toEqual({
                 statusCode: 666,
-                body: {reason: 'oops'},
+                body: '{"reason":"oops"}',
                 headers: expectedCorsHeaders
             });
             done();
@@ -384,7 +384,7 @@ describe('proxyIntegration.routeHandler.returnvalues', () => {
         proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(result => {
             expect(result).toEqual({
                 statusCode: 599,
-                body: 'doof',
+                body: '"doof"',
                 headers: {"Content-Type": "application/json"}
             });
             done();

--- a/test/proxyIntegration.spec.js
+++ b/test/proxyIntegration.spec.js
@@ -328,7 +328,30 @@ describe('proxyIntegration.routeHandler', () => {
         proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(result => {
             expect(result).toEqual({
                 statusCode: 500,
-                body: 'Generic error: ' + JSON.stringify(incorrectError)
+                body: 'Generic error: ' + JSON.stringify(incorrectError),
+                headers: expectedCorsHeaders
+            });
+            done();
+        });
+    });
+    it('should pass through error statuscode', (done) => {
+        const statusCodeError = {status: 666, message: {reason: 'oops'}};
+        const routeConfig = {
+            routes: [
+                {
+                    method: 'GET',
+                    path: '/',
+                    action: () => {
+                        throw statusCodeError
+                    }
+                }
+            ]
+        };
+        proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(result => {
+            expect(result).toEqual({
+                statusCode: 666,
+                body: {reason: 'oops'},
+                headers: expectedCorsHeaders
             });
             done();
         });


### PR DESCRIPTION
errormessage does not have to be a string, allow to return statuscode directly, also send headers (e.g. CORS!!) if Generic error